### PR TITLE
Adding Helm 3 scenario

### DIFF
--- a/docs/helm3-in-action.md
+++ b/docs/helm3-in-action.md
@@ -3,6 +3,7 @@ Helm with OpenShift.
 
 ## Self-Paced Learning
 
+* [OpenShift: Interactive Learning Portal — Getting Started with Helm 3 on OpenShift](https://learn.openshift.com/developing-on-openshift/helm/)
 * [OpenShift: Interactive Learning Portal — Operator SDK with Helm](https://learn.openshift.com/operatorframework/helm-operator/)
 
 ## Additional Resources


### PR DESCRIPTION
Inserted at the beginning on the list since the follow-up of the scenario, from the final page, is proper the `Operator SDK with Helm` one with a link to it.